### PR TITLE
Add reusable `Wait` method to improve test readability

### DIFF
--- a/src/test/java/Comments.java
+++ b/src/test/java/Comments.java
@@ -27,6 +27,18 @@ public class Comments {
         commentBox.sendKeys("Automation Working");
     }
 
+    /**
+     * Pauses the execution of the current thread for a specified duration.
+     *
+     * @param seconds The duration to pause, expressed in seconds.
+     */
+    public void Wait(int seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
     @AfterTest
     public void tearDown() {
         driver.quit();

--- a/src/test/java/Login.java
+++ b/src/test/java/Login.java
@@ -16,7 +16,7 @@ import org.testng.annotations.Test;
  * It uses Selenium WebDriver and TestNG to perform the tests and validate the login functionality.
  * The various scenarios tested include successful login, login failures with incorrect or empty fields,
  * logging out, and verifying redirects after logout.
- *
+ * <p>
  * Methods in this class are annotated with TestNG annotations for setup, testing, and teardown operations.
  */
 public class Login {
@@ -45,141 +45,150 @@ public class Login {
 
     /**
      * Tests the login functionality with valid credentials.
-     *
+     * <p>
      * This test performs the following actions:
      * 1. Navigates to the login page by clicking the sign-in link.
      * 2. Enters a valid email address into the email field and proceeds to the next step.
      * 3. Waits for the password field to become visible and enters a valid password.
      * 4. Completes the login process by submitting the credentials.
-     *
+     * <p>
      * The test validates successful login by ensuring the presence of the avatar button,
      * which signifies that the user has been authenticated and redirected to the appropriate page.
-     *
+     * <p>
      * Assertions:
      * - Validates that the avatar button is displayed after logging in with valid credentials.
-     *
+     * <p>
      * Priority:
      * - This test is assigned a priority of 1, indicating it should run early in the test sequence.
      */
-    @Test (description = "Tests logging in with valid credentials", priority = 1)
+    @Test(description = "Tests logging in with valid credentials", priority = 1)
     public void testValidLogin() {
         driver.findElement(By.xpath("//a[@aria-label='Sign in']")).click();
         driver.findElement(By.id("identifierId")).sendKeys(correctEmail);
+        Wait(3);
         driver.findElement(By.id("identifierNext")).click();
 
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.name("Passwd")));
         driver.findElement(By.name("Passwd")).sendKeys(correctPassword);
+        Wait(3);
         driver.findElement(By.id("passwordNext")).click();
 
         wait.until(ExpectedConditions.presenceOfElementLocated(By.xpath("//button[@id='avatar-btn']")));
         Assert.assertTrue(driver.findElement(By.id("avatar-btn")).isDisplayed(), "Login failed with valid credentials.");
+        Wait(3);
     }
 
     /**
      * Tests the logout functionality of the application.
-     *
+     * <p>
      * This method performs the following actions:
      * 1. Triggers the logout dropdown menu by clicking the avatar button.
      * 2. Waits for the "Sign out" option to become visible and selects it.
      * 3. Verifies successful logout by checking for the presence of "Sign in" on the page.
-     *
+     * <p>
      * Assertions:
      * - Validates that the "Sign in" text is present on the page, which indicates
-     *   that the logout process was successful.
-     *
+     * that the logout process was successful.
+     * <p>
      * Priority:
      * - This test is assigned a priority of 2, indicating it should run after the login test.
      *
      * @throws InterruptedException if the thread is interrupted during the wait.
      */
-    @Test (description = "Tests logging out the user", priority = 2)
+    @Test(description = "Tests logging out the user", priority = 2)
     public void testLogout() throws InterruptedException {
         driver.findElement(By.id("avatar-btn")).click();
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.partialLinkText("Sign out"))).click();
         Assert.assertTrue(driver.getPageSource().contains("Sign in"), "User may not be logged out.");
-        Thread.sleep(3000);
+        Wait(3);
     }
 
     /**
      * Tests if the user is redirected to the homepage after logging out.
-     *
+     * <p>
      * This test performs the following actions:
      * 1. Waits for a brief duration to allow redirection to complete.
      * 2. Retrieves the current URL of the browser.
      * 3. Validates that the user has been redirected to the homepage by asserting
-     *    that the URL contains "youtube.com".
-     *
+     * that the URL contains "youtube.com".
+     * <p>
      * Assertions:
      * - Validates that the current URL after logout contains "youtube.com",
-     *   ensuring that the redirection to the homepage was successful.
-     *
+     * ensuring that the redirection to the homepage was successful.
+     * <p>
      * Priority:
      * - This test is assigned a priority of 3, indicating it should run
-     *   after the logout test.
+     * after the logout test.
      *
      * @throws InterruptedException if the thread is interrupted during the wait.
      */
-    @Test (description = "Tests if user is redirected to homepage after logout", priority = 3)
+    @Test(description = "Tests if user is redirected to homepage after logout", priority = 3)
     public void testLogoutRedirect() throws InterruptedException {
-        Thread.sleep(3000);
         String currentUrl = driver.getCurrentUrl();
         System.out.println(currentUrl);
         Assert.assertTrue(currentUrl.contains("youtube.com"), "User was not redirected to the homepage.");
+        Wait(3);
     }
 
     /**
      * Tests the login functionality with invalid credentials.
-     *
+     * <p>
      * This method performs the following actions:
      * 1. Navigates to the login page by clicking the sign-in link.
      * 2. Selects the option to use another account.
      * 3. Enters a valid email address into the email field and proceeds to the next step.
      * 4. Waits for the password field to become visible and enters an invalid password.
      * 5. Submits the invalid credentials and waits for the error message to appear.
-     *
+     * <p>
      * The test validates that the error message for a wrong password is displayed.
-     *
+     * <p>
      * Assertions:
      * - Verifies that the error message indicating a wrong password is visible.
-     *
+     * <p>
      * Priority:
      * - This test is assigned a priority of 4, indicating it should run later in the test sequence.
      *
      * @throws InterruptedException if the thread is interrupted during the wait.
      */
-    @Test (description = "Tests logging in with invalid credentials", priority = 4)
+    @Test(description = "Tests logging in with invalid credentials", priority = 4)
     public void testInvalidLogin() throws InterruptedException {
+        Wait(3);
         driver.findElement(By.xpath("//a[@aria-label='Sign in']")).click();
+        Wait(3);
         driver.findElement(By.xpath("//div[contains(text(), 'Use another account')]")).click();
+        Wait(3);
         driver.findElement(By.id("identifierId")).sendKeys(correctEmail);
+        Wait(3);
         driver.findElement(By.id("identifierNext")).click();
 
         wait.until(ExpectedConditions.visibilityOfElementLocated(By.name("Passwd")));
         driver.findElement(By.name("Passwd")).sendKeys(incorrectPassword);
+        Wait(3);
         driver.findElement(By.id("passwordNext")).click();
 
         WebElement error = wait.until(ExpectedConditions.visibilityOfElementLocated(
                 By.xpath("//span[contains(text(), 'Wrong password')]")
         ));
         Assert.assertTrue(error.isDisplayed(), "Error message for wrong password not shown.");
+        Wait(3);
     }
 
     /**
      * Tests logging in with no credentials inputted.
-     *
+     * <p>
      * This test performs the following actions:
      * 1. Navigates to the login page by clicking the sign-in link.
      * 2. Attempts to proceed without entering any credentials.
      * 3. Waits for the error message prompting the user to enter an email to become visible.
      * 4. Validates that the error message is displayed when required fields are left empty.
-     *
+     * <p>
      * Assertions:
      * - Verifies that the error message for empty fields is visible.
-     *
+     * <p>
      * Priority:
      * - This test is assigned a priority of 5, indicating it should run later in the test sequence.
      */
-    @Test (description = "Tests logging in with no credentials inputted", priority = 5)
+    @Test(description = "Tests logging in with no credentials inputted", priority = 5)
     public void testEmptyLoginFields() {
         driver.get("https://www.youtube.com");
         driver.findElement(By.xpath("//a[@aria-label='Sign in']")).click();
@@ -190,12 +199,25 @@ public class Login {
                 By.xpath("//div[contains(text(), 'Enter an email')]")
         ));
         Assert.assertTrue(error.isDisplayed(), "Error message for empty field not shown.");
+        Wait(3);
     }
 
+    /**
+     * Pauses the execution of the current thread for a specified duration.
+     *
+     * @param seconds The duration to pause, expressed in seconds.
+     */
+    public void Wait(int seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
 
     /**
      * Cleans up the test environment after all tests have been executed.
-     *
+     * <p>
      * This method closes and quits the WebDriver instance that was initialized
      * for running the tests, ensuring that browser resources are properly released.
      * It is executed after all test methods in the test class have completed.

--- a/src/test/java/Search.java
+++ b/src/test/java/Search.java
@@ -1,2 +1,14 @@
 public class Search {
+    /**
+     * Pauses the execution of the current thread for a specified duration.
+     *
+     * @param seconds The duration to pause, expressed in seconds.
+     */
+    public void Wait(int seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/test/java/Settings.java
+++ b/src/test/java/Settings.java
@@ -5,4 +5,16 @@ public class Settings {
     WebDriver driver;
     WebDriverWait wait;
 
+    /**
+     * Pauses the execution of the current thread for a specified duration.
+     *
+     * @param seconds The duration to pause, expressed in seconds.
+     */
+    public void Wait(int seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
 }

--- a/src/test/java/Video.java
+++ b/src/test/java/Video.java
@@ -1,2 +1,16 @@
 public class Video {
+
+    /**
+     * Pauses the execution of the current thread for a specified duration.
+     *
+     * @param seconds The duration to pause, expressed in seconds.
+     */
+    public void Wait(int seconds) {
+        try {
+            Thread.sleep(seconds * 1000L);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+
 }


### PR DESCRIPTION
The `Wait` method was implemented across multiple test classes for consistent and reusable thread pausing. This change replaces redundant `Thread.sleep` calls, enhancing code readability and maintainability.